### PR TITLE
Fix test for rust segment

### DIFF
--- a/powerlevel9k.zsh-theme
+++ b/powerlevel9k.zsh-theme
@@ -1114,6 +1114,7 @@ prompt_rust_version() {
     "$1_prompt_segment" "$0" "$2" "208" "$DEFAULT_COLOR" "$rust_version" 'RUST_ICON'
   fi
 }
+
 # RSpec test ratio
 prompt_rspec_stats() {
   if [[ (-d app && -d spec) ]]; then

--- a/test/segments/rust_version.spec
+++ b/test/segments/rust_version.spec
@@ -5,28 +5,39 @@
 setopt shwordsplit
 SHUNIT_PARENT=$0
 
+TEST_BASE_FOLDER=/tmp/powerlevel9k-test
+RUST_TEST_FOLDER="${TEST_BASE_FOLDER}/rust-test"
+
 function setUp() {
+  OLDPATH="${PATH}"
+  mkdir -p "${RUST_TEST_FOLDER}"
+  PATH="${RUST_TEST_FOLDER}:${PATH}"
+
   export TERM="xterm-256color"
   # Load Powerlevel9k
   source powerlevel9k.zsh-theme
 }
 
+function tearDown() {
+  PATH="${OLDPATH}"
+  rm -fr "${TEST_BASE_FOLDER}"
+}
+
 function mockRust() {
-  echo 'rustc  0.4.1a-alpha'
+  echo "#!/bin/sh\n\necho 'rustc 0.4.1a-alpha'" > "${RUST_TEST_FOLDER}/rustc"
+  chmod +x "${RUST_TEST_FOLDER}/rustc"
 }
 
 function testRust() {
-  alias rustc=mockRust
+  mockRust
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(rust_version)
 
   assertEquals "%K{208} %F{black}0.4.1a-alpha %k%F{208}%f " "$(build_left_prompt)"
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
-  unalias rustc
 }
 
 function testRustPrintsNothingIfRustIsNotAvailable() {
-  alias rustc=noRust
   POWERLEVEL9K_CUSTOM_WORLD='echo world'
   POWERLEVEL9K_LEFT_PROMPT_ELEMENTS=(custom_world rust_version)
 
@@ -34,7 +45,6 @@ function testRustPrintsNothingIfRustIsNotAvailable() {
 
   unset POWERLEVEL9K_LEFT_PROMPT_ELEMENTS
   unset POWERLEVEL9K_CUSTOM_WORLD
-  unalias rustc
 }
 
 source shunit2/source/2.1/src/shunit2


### PR DESCRIPTION
I found a way to mock rust even when the `command` builtin is used. We need to modify the `PATH` and add our own `rustc` (which is a script that just outputs the version number).